### PR TITLE
Updated to most recent version of sqljocky

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,4 +5,4 @@ author: Zyrthofar <zyrthofar@magnetfruit.com>
 homepage: 'http://www.magnetfruit.com/databasehandler/'
 dependencies:
   magnetfruit_database_handler: ">=0.1.2 <0.2.0"
-  sqljocky: 0.11.0
+  sqljocky: 0.14.1


### PR DESCRIPTION
Have been running into errors when SELECTing from tables with Strings. At some point, sqljocky calls .toList() on a Results object (implements Stream). Once the toList() call resolves, any Dart String fields become Dart Blob objects, with the _string field equal to their previous value.

SQLJocky has updated several times since this has been changed, so it stands to reason this issue may not exist anymore.